### PR TITLE
Refactor JobsDB data indexing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ pretty:
 
 # run tests
 test:
-	.venv/bin/pytest
+	PYTHONPATH=$(PWD) .venv/bin/python -m pytest -v
 
 # clean up the code
 clean: check_fix pretty check_types test openapi

--- a/backend/db.py
+++ b/backend/db.py
@@ -33,8 +33,8 @@ class JobsDB:
 
     def create_jobs_table(self):
         with closing(sqlite3.connect(self.path)) as connection:
+            connection.execute("PRAGMA foreign_keys = ON")
             with closing(connection.cursor()) as cursor:
-                connection.execute("PRAGMA foreign_keys = ON")
                 cursor.execute(
                     """
                     CREATE TABLE IF NOT EXISTS jobs (
@@ -50,8 +50,8 @@ class JobsDB:
         job: Job,
     ):
         with closing(sqlite3.connect(self.path)) as connection:
+            connection.execute("PRAGMA foreign_keys = ON")
             with closing(connection.cursor()) as cursor:
-                connection.execute("PRAGMA foreign_keys = ON")
                 cursor.execute(
                     """
                     INSERT INTO jobs(
@@ -73,8 +73,8 @@ class JobsDB:
     ) -> list[Job]:
         with closing(sqlite3.connect(self.path)) as connection:
             connection.row_factory = dict_factory
+            connection.execute("PRAGMA foreign_keys = ON")
             with closing(connection.cursor()) as cursor:
-                connection.execute("PRAGMA foreign_keys = ON")
                 cursor.execute(
                     """
                     SELECT
@@ -95,8 +95,8 @@ class JobsDB:
     ) -> Job:
         with closing(sqlite3.connect(self.path)) as connection:
             connection.row_factory = dict_factory
+            connection.execute("PRAGMA foreign_keys = ON")
             with closing(connection.cursor()) as cursor:
-                connection.execute("PRAGMA foreign_keys = ON")
                 cursor.execute(
                     """
                     SELECT
@@ -157,8 +157,8 @@ class JobsDB:
         job_id: UUID,
     ):
         with closing(sqlite3.connect(self.path)) as connection:
+            connection.execute("PRAGMA foreign_keys = ON")
             with closing(connection.cursor()) as cursor:
-                connection.execute("PRAGMA foreign_keys = ON")
                 cursor.execute(
                     """
                     DELETE FROM jobs 

--- a/backend/db.py
+++ b/backend/db.py
@@ -127,6 +127,7 @@ class JobsDB:
         job: Job,
     ) -> Job:
         with closing(sqlite3.connect(self.path)) as connection:
+            connection.row_factory = dict_factory
             connection.execute("PRAGMA foreign_keys = ON")
             with closing(connection.cursor()) as cursor:
                 cursor.execute(
@@ -149,10 +150,7 @@ class JobsDB:
                     )
                 connection.commit()
 
-                return Job(
-                    id=row[0],
-                    name=str(row[1]),
-                )
+                return read_job(row)
 
     def delete_job(
         self,

--- a/backend/util/__init__.py
+++ b/backend/util/__init__.py
@@ -1,0 +1,5 @@
+from backend.util.dict_factory import dict_factory
+
+__all__ = [
+    "dict_factory",
+]

--- a/backend/util/dict_factory.py
+++ b/backend/util/dict_factory.py
@@ -6,6 +6,8 @@ def dict_factory(cursor: Cursor, row: Row) -> Dict[str, Any]:
     """
     This function is used to convert the sqlite3.Row object to a dictionary.
 
+    Visit https://docs.python.org/3/library/sqlite3.html#sqlite3.Connection.row_factory for more information on configuring row factories.
+
     Usage:
         ```python
         connection.row_factory = dict_factory

--- a/backend/util/dict_factory.py
+++ b/backend/util/dict_factory.py
@@ -8,7 +8,7 @@ def dict_factory(cursor: Cursor, row: Row) -> Dict[str, Any]:
 
     Usage:
         ```python
-        cursor.row_factory = dict_factory
+        connection.row_factory = dict_factory
         cursor.execute("SELECT * FROM jobs")
         jobs = cursor.fetchall()
         for job in jobs:

--- a/backend/util/dict_factory.py
+++ b/backend/util/dict_factory.py
@@ -1,0 +1,26 @@
+from sqlite3 import Cursor, Row
+from typing import Dict, Any
+
+
+def dict_factory(cursor: Cursor, row: Row) -> Dict[str, Any]:
+    """
+    This function is used to convert the sqlite3.Row object to a dictionary.
+
+    Usage:
+        ```python
+        cursor.row_factory = dict_factory
+        cursor.execute("SELECT * FROM jobs")
+        jobs = cursor.fetchall()
+        for job in jobs:
+            print(job['id'], job['name'], job['created_date'])
+        ```
+
+    Parameters:
+        cursor (sqlite3.Cursor): The cursor object.
+        row (sqlite3.Row): The row object.
+
+    Returns:
+        Dict[str, Any]: The row object keyed by column names.
+    """
+
+    return {column[0]: row[index] for index, column in enumerate(cursor.description)}

--- a/tests/util/dict_factory_test.py
+++ b/tests/util/dict_factory_test.py
@@ -1,0 +1,35 @@
+import sqlite3
+import pytest
+from unittest.mock import MagicMock
+from backend.util import dict_factory
+
+
+@pytest.fixture
+def mock_database_connection():
+    # Mocking the cursor and row objects
+    cursor = MagicMock(spec=sqlite3.Cursor)
+    row = MagicMock(spec=sqlite3.Row)
+    cursor.description = [("id", None), ("name", None), ("created_date", None)]
+    return cursor, row
+
+
+def test_dict_factory(mock_database_connection):
+    cursor, row = mock_database_connection
+    row_data = (1, "Test Job", "2024-03-07")
+    row.__getitem__.side_effect = row_data.__getitem__
+
+    result = dict_factory(cursor, row)
+
+    assert result == {"id": 1, "name": "Test Job", "created_date": "2024-03-07"}
+
+
+def test_dict_factory_empty_row(mock_database_connection):
+    cursor, row = mock_database_connection
+
+    # Mocking an empty row by returning None for all indices
+    row.__getitem__.side_effect = lambda _: None
+
+    result = dict_factory(cursor, row)
+
+    # Check if the result is an empty dictionary with default values
+    assert result == {"id": None, "name": None, "created_date": None}

--- a/tests/util/dict_factory_test.py
+++ b/tests/util/dict_factory_test.py
@@ -6,10 +6,11 @@ from backend.util import dict_factory
 
 @pytest.fixture
 def mock_database_connection():
-    # Mocking the cursor and row objects
     cursor = MagicMock(spec=sqlite3.Cursor)
     row = MagicMock(spec=sqlite3.Row)
+
     cursor.description = [("id", None), ("name", None), ("created_date", None)]
+
     return cursor, row
 
 
@@ -21,15 +22,3 @@ def test_dict_factory(mock_database_connection):
     result = dict_factory(cursor, row)
 
     assert result == {"id": 1, "name": "Test Job", "created_date": "2024-03-07"}
-
-
-def test_dict_factory_empty_row(mock_database_connection):
-    cursor, row = mock_database_connection
-
-    # Mocking an empty row by returning None for all indices
-    row.__getitem__.side_effect = lambda _: None
-
-    result = dict_factory(cursor, row)
-
-    # Check if the result is an empty dictionary with default values
-    assert result == {"id": None, "name": None, "created_date": None}


### PR DESCRIPTION
# Motivation

Currently we're indexing items in the database using numerical indexes, I think it makes sense instead to index them by the column name in the database.

# Example

Before:
```python
with closing(sqlite3.connect(self.path)) as connection:
    with closing(connection.cursor()) as cursor:
        connection.execute("PRAGMA foreign_keys = ON")
        cursor.execute(
            """
            SELECT
                id,
                name,
                datetime(created_date,'utc') as created_date
            FROM 
                jobs
            ;
            """,
        )
        for row in cursor.fetchall():
            id = row[0]
            name = row[1]
            created_date = row[2]
```

After:
```python
with closing(sqlite3.connect(self.path)) as connection:
    connection.row_factory = dict_factory
    with closing(connection.cursor()) as cursor:
        connection.execute("PRAGMA foreign_keys = ON")
        cursor.execute(
            """
            SELECT
                id,
                name,
                datetime(created_date,'utc') as created_date
            FROM 
                jobs
            ;
            """,
        )
        for row in cursor.fetchall():
            id = row["id"]
            name = row["name"]
            created_date = row["created_date"]
```

# Summary

This commit introduces a new method called `dict_factory` that implements the [row factory](https://docs.python.org/3/library/sqlite3.html#how-to-create-and-use-row-factories) protocol on the sqlite3 connection class.

I've also implemented `dict_factory` in the JobsDB class and updated the `read_job` method to accept a dictionary representing the database row.